### PR TITLE
feat(openssl-static): publish static-only OpenSSL prefab AAR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - openssl
+          - openssl-static
           - sodium
           - curl
           - utf8proc

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ fabric.properties
 /sodium/*
 !/sodium/build.gradle.kts
 !/sodium/android-aar.sh
+/openssl-static/*
+!/openssl-static/build.gradle.kts

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,11 @@ extra["projectConfigs"] = mapOf(
         "libName" to "OpenSSL",
         "snapshotVersion" to "1"
     ),
+    "openssl-static" to mapOf(
+        "libVersion" to "3.6.2",
+        "libName" to "OpenSSL",
+        "snapshotVersion" to "1"
+    ),
     "jsoncpp" to mapOf(
         "libVersion" to "1.9.5",
         "libName" to "JsonCpp"

--- a/openssl-static/build.gradle.kts
+++ b/openssl-static/build.gradle.kts
@@ -1,0 +1,261 @@
+import com.android.ndkports.AdHocPortTask
+import com.android.ndkports.AndroidExecutableTestTask
+import com.android.ndkports.CMakeCompatibleVersion
+import java.io.File
+import java.net.URL
+import java.security.MessageDigest
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.TaskAction
+
+// Get project-specific configuration
+val configs = rootProject.extra["projectConfigs"] as Map<String, Map<String, String>>
+val projectConfig = configs[project.name] ?: error("No configuration found for project ${project.name}")
+
+val libVersion = projectConfig["libVersion"]!!
+val snapshotVersion = projectConfig["snapshotVersion"] ?: ""
+
+val opensslDownloadUrl = "https://github.com/openssl/openssl/releases/download/openssl-${libVersion}/openssl-${libVersion}.tar.gz"
+val opensslSha256Url = "${opensslDownloadUrl}.sha256"
+val opensslAscUrl = "${opensslDownloadUrl}.asc"
+
+group = "io.github.ronickg"
+version = if (snapshotVersion.isNotEmpty()) "$libVersion-$snapshotVersion" else libVersion
+
+plugins {
+    id("maven-publish")
+    id("com.android.ndkports.NdkPorts")
+    id("signing")
+    distribution
+}
+
+ndkPorts {
+    ndkPath.set(File(project.findProperty("ndkPath") as String))
+    source.set(project.file("src.tar.gz"))
+    minSdkVersion.set(21)
+}
+
+// Task to download OpenSSL source
+tasks.register<DefaultTask>("downloadOpenSSL") {
+    val outputFile = project.file("src.tar.gz")
+    val sha256File = project.file("openssl.sha256")
+    val ascFile = project.file("openssl.asc")
+
+    outputs.file(outputFile)
+    outputs.file(sha256File)
+    outputs.file(ascFile)
+
+    doLast {
+        // Download source
+        URL(opensslDownloadUrl).openStream().use { input ->
+            outputFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        // Download SHA256
+        URL(opensslSha256Url).openStream().use { input ->
+            sha256File.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        // Download ASC signature
+        URL(opensslAscUrl).openStream().use { input ->
+            ascFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        // Set the source property after download
+        ndkPorts.source.set(outputFile)
+    }
+}
+
+// Task to verify OpenSSL integrity
+tasks.register<DefaultTask>("verifyOpenSSL") {
+    dependsOn("downloadOpenSSL")
+
+    doLast {
+        val sourceFile = project.file("src.tar.gz")
+        val sha256File = project.file("openssl.sha256")
+        val ascFile = project.file("openssl.asc")
+
+        // Read expected SHA256
+        val expectedHash = sha256File.readText().trim().split(" ")[0]
+
+        // Calculate actual SHA256
+        val digest = MessageDigest.getInstance("SHA-256")
+        val actualHash = sourceFile.inputStream().use { input ->
+            digest.digest(input.readBytes())
+        }.joinToString("") { "%02x".format(it) }
+
+        // Verify hash
+        if (expectedHash != actualHash) {
+            throw GradleException("SHA256 verification failed! Expected: $expectedHash, Got: $actualHash")
+        } else {
+            println("SHA256 verification succeeded.")
+        }
+
+        // Import OpenSSL PGP key first
+        exec {
+            commandLine(
+                "gpg",
+                "--keyserver",
+                "keyserver.ubuntu.com",
+                "--recv-keys",
+                "BA5473A2B0587B07FB27CF2D216094DFD0CB81EF"  // OpenSSL release signing key
+            )
+        }
+
+        // Verify the signature
+        exec {
+            commandLine("gpg", "--verify", ascFile.absolutePath, sourceFile.absolutePath)
+        }
+
+        println("GPG signature verification succeeded.")
+    }
+}
+
+tasks.named("extractSrc") {
+    dependsOn("verifyOpenSSL")
+}
+
+
+val buildTask = tasks.register<AdHocPortTask>("buildPort") {
+    dependsOn("extractSrc")
+
+    builder {
+        run {
+            args(
+                sourceDirectory.resolve("Configure").absolutePath,
+                "android-${toolchain.abi.archName}",
+                "-D__ANDROID_API__=${toolchain.api}",
+                "--prefix=${installDirectory.absolutePath}",
+                "--openssldir=${installDirectory.absolutePath}",
+                "no-sctp",
+                "no-shared",
+                // consumers link libcrypto.a into their own .so, so every object
+                // must be position independent
+                "-fPIC",
+                "-Wl,-z,max-page-size=16384",
+                "-fstack-protector-strong",
+                "-D_FORTIFY_SOURCE=2"
+            )
+
+            env("ANDROID_NDK", toolchain.ndk.path.absolutePath)
+            env("PATH", "${toolchain.binDir}:${System.getenv("PATH")}")
+        }
+
+        run {
+            args("make", "-j$ncpus")
+
+            env("ANDROID_NDK", toolchain.ndk.path.absolutePath)
+            env("PATH", "${toolchain.binDir}:${System.getenv("PATH")}")
+        }
+
+        run {
+            args("make", "install_sw")
+
+            env("ANDROID_NDK", toolchain.ndk.path.absolutePath)
+            env("PATH", "${toolchain.binDir}:${System.getenv("PATH")}")
+        }
+    }
+}
+
+tasks.prefabPackage {
+    version.set(CMakeCompatibleVersion.parse(libVersion))
+
+    licensePath.set("LICENSE.txt")
+
+    modules {
+        create("ssl") {
+            static.set(true)
+            dependencies.set(listOf(":crypto"))
+        }
+        create("crypto") { static.set(true) }
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["prefab"])
+            pom {
+                name.set("OpenSSL (static)")
+                description.set("The ndkports AAR for OpenSSL, static libraries only.")
+                val repoUrl = "https://github.com/${System.getenv("GITHUB_REPOSITORY") ?: "user/repo"}"
+                url.set(repoUrl)
+                licenses {
+                    license {
+                        name.set("Dual OpenSSL and SSLeay License")
+                        url.set("https://www.openssl.org/source/license-openssl-ssleay.txt")
+                        distribution.set("repo")
+                    }
+                }
+                developers {
+                    developer {
+                        name.set("Ronald")
+                    }
+                }
+                scm {
+                    url.set(repoUrl)
+                    connection.set("scm:git:${repoUrl}.git")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            url = uri("${project.buildDir}/repository")
+        }
+    }
+}
+
+// Configure signing
+signing {
+    useGpgCmd()
+    sign(publishing.publications["maven"])
+}
+
+distributions {
+    main {
+        contents {
+            from("${project.buildDir}/repository")
+
+            into("/") // Force files to be at root of zip
+
+            include("**/*.aar")
+            include("**/*.pom")
+            include("**/*.module")
+            include("**/*.aar.asc")
+            include("**/*.pom.asc")
+            include("**/*.module.asc")
+            include("**/*.aar.md5")
+            include("**/*.pom.md5")
+            include("**/*.module.md5")
+            include("**/*.aar.sha1")
+            include("**/*.pom.sha1")
+            include("**/*.module.sha1")
+            include("**/*.aar.sha256")
+            include("**/*.pom.sha256")
+            include("**/*.module.sha256")
+            include("**/*.aar.sha512")
+            include("**/*.pom.sha512")
+            include("**/*.module.sha512")
+            include("**/maven-metadata.xml")
+            include("**/maven-metadata.xml.asc")
+            include("**/maven-metadata.xml.sha256")
+            include("**/maven-metadata.xml.sha512")
+        }
+    }
+}
+
+tasks {
+    distZip {
+        dependsOn("publish")
+        destinationDirectory.set(File(rootProject.buildDir, "distributions"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ pluginManagement {
 
 include("curl")
 include("openssl")
+include("openssl-static")
 include("utf8proc")
 include("gmp")
 include("jsoncpp")


### PR DESCRIPTION
## Why

The `openssl` port ships `libcrypto.so`/`libssl.so`. When two Android libraries in the same app depend on it at different versions, each packages its own copy and `mergeNativeLibs` fails:

```
Execution failed for task ':app:mergeDebugNativeLibs'.
   > 2 files found with path 'lib/arm64-v8a/libcrypto.so'
```

`pickFirst` makes the build pass but leaves whichever library lost the coin toss bound to an OpenSSL it wasn't compiled against — corruption or `SIGSEGV` inside OpenSSL rather than a clean error.

Concretely: `react-native-quick-crypto` uses `io.github.ronickg:openssl:3.6.2-1` and `@op-engineering/op-sqlite` (with SQLCipher) uses `3.3.2-1`. See margelo/react-native-quick-crypto#1059.

## What

Adds an `openssl-static` port alongside the existing `openssl` one. A consumer that links these archives into its own `.so` can localize the symbols with `-Wl,--exclude-libs,ALL`, so it ships no `libcrypto.so` at all and its OpenSSL cannot interpose on (or be interposed by) anyone else's.

Kept as a separate artifact rather than extra modules on the existing `openssl` port: a combined AAR would still carry the `.so`, so AGP would still package it and the collision would remain.

- `no-shared` + `-fPIC` (OpenSSL doesn't add `-fPIC` on its own with `no-shared`, and these archives get linked into shared libraries)
- prefab modules `crypto`/`ssl` marked `static`, with `ssl` depending on `:crypto`
- dropped the `SHLIB_EXT=.so` make args, which no longer apply
- added to the release workflow's library dropdown; publishing reuses the existing `:openssl-static:distZip` flow, no new CI machinery

## Testing

Not yet built through this Gradle port — publishing needs your signing keys. The equivalent OpenSSL 3.6.2 configuration (`no-shared -fPIC`, same symbol layout) was built and verified on the Apple toolchain: static `libcrypto.a`/`libssl.a` produced, linked into a consumer, and exercised at runtime.

Happy to adjust the artifact name or module naming if you'd prefer something else.