### PR TITLE
fix(openssl-static): use a hyphen-free prefab package name

### DIFF
--- a/openssl-static/build.gradle.kts
+++ b/openssl-static/build.gradle.kts
@@ -165,6 +165,18 @@ val buildTask = tasks.register<AdHocPortTask>("buildPort") {
 }
 
 tasks.prefabPackage {
+    // Not the project name: PrefabPackageBuilder derives the AAR's manifest
+    // package from this as io.github.ronickg.<name>, and a hyphen there is not
+    // a valid Java identifier, so AGP rejects the AAR outright:
+    //
+    //   Package 'io.github.ronickg.openssl-static' from AndroidManifest.xml is
+    //   not a valid Java package name
+    //
+    // The Maven artifactId still comes from the project name, so the
+    // io.github.ronickg:openssl-static coordinate is unaffected. Consumers do
+    // find_package(opensslstatic) and link opensslstatic::crypto.
+    packageName.set("opensslstatic")
+
     version.set(CMakeCompatibleVersion.parse(libVersion))
 
     licensePath.set("LICENSE.txt")


### PR DESCRIPTION
Follow-up to #5. `openssl-static:3.6.2-1` is unusable as published — my fault, and I should have built an app against it before it went to Central.

## The bug

`PrefabPackageBuilder` composes the AAR's manifest package as `io.github.ronickg.${packageName}`, which defaults to the Gradle project name. For this port that yields `io.github.ronickg.openssl-static`, and AGP rejects it at `processDebugResources` — before any native code is even compiled:

```
java.lang.IllegalArgumentException: Package 'io.github.ronickg.openssl-static' from
AndroidManifest.xml is not a valid Java package name as 'openssl-static' is not a
valid Java identifier.
```

This never surfaced on the existing ports because none of them have a hyphen at the *package* level — `sodium` has hyphenated *module* names (`sodium-static`), which are fine, since only the package name reaches the manifest.

## The fix

Set `packageName.set("opensslstatic")`. One line, no `buildSrc` change.

The Maven artifactId comes from the project name, so **`io.github.ronickg:openssl-static` is unchanged**. Only the CMake-facing names move:

```cmake
find_package(opensslstatic REQUIRED CONFIG)
target_link_libraries(mylib opensslstatic::ssl opensslstatic::crypto)
```

## Verification

I patched the published `3.6.2-1` AAR's `AndroidManifest.xml` and `prefab.json` to exactly the values this change produces, installed it locally, and built a real app (react-native-quick-crypto's example) against it:

- builds and links across all 4 ABIs
- the APK ships **no** `libcrypto.so` / `libssl.so` — which is the whole point of the port
- `libQuickCrypto.so` exports **0** OpenSSL symbols in its dynamic table (with `-Wl,--exclude-libs,ALL`), while `JNI_OnLoad` and the Nitro entry points stay exported
- OpenSSL code is present but local (`t`), e.g. `EVP_MD_CTX_new`, `X509_free`

Since Central is immutable, `3.6.2-1` will have to stay there dead; this needs a release run to publish `3.6.2-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)